### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -14,22 +14,22 @@ jobs:
     name: run fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/workflows/setup-rust
-      - uses: actions-rust-lang/rustfmt@v1
+      - uses: actions-rust-lang/rustfmt@4066006ec54a31931b9b1fddfd38f2fdf2d27143 # v1.1.2
 
   clippy:
     name: run clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/workflows/setup-rust
         with:
           cache: read
-      - uses: arduino/setup-protoc@v1
+      - uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: clippy
           args: --tests -- -D warnings
@@ -38,11 +38,11 @@ jobs:
     name: run unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/workflows/setup-rust
         with:
           cache: read
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: test
           args: --workspace --exclude integration_tests

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -13,7 +13,7 @@ jobs:
   benchmarks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/workflows/setup-rust
         with:
           cache: read
@@ -22,7 +22,7 @@ jobs:
         run: |
           bash ./scripts/ci-run-benchmarks.sh . ${{ github.job }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: canbench_result_${{github.job}}
           path: /tmp/canbench_result_${{ github.job }}
@@ -31,7 +31,7 @@ jobs:
         run: |
           echo ${{ github.event.number }} > /tmp/pr_number
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pr_number
           path: /tmp/pr_number

--- a/.github/workflows/build_caches.yaml
+++ b/.github/workflows/build_caches.yaml
@@ -10,11 +10,11 @@ jobs:
     name: Build all in debug mode
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/workflows/setup-rust
         with:
           cache: write
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: build
           args: --tests

--- a/.github/workflows/canbench-post-comment.yaml
+++ b/.github/workflows/canbench-post-comment.yaml
@@ -13,9 +13,9 @@ jobs:
       matrix: ${{ steps.set-benchmarks.outputs.matrix }}
       pr_number: ${{ steps.set-benchmarks.outputs.pr_number }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: dawidd6/action-download-artifact@v7
+      - uses: dawidd6/action-download-artifact@80620a5d27ce0ae443b965134db88467fc607b43 # v7
         with:
           run_id: ${{ github.event.workflow_run.id }}
 
@@ -29,7 +29,7 @@ jobs:
       matrix: ${{fromJSON(needs.download-results.outputs.matrix)}}
     steps:
       - name: Post comment
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           message: |
             ${{ matrix.benchmark.result }}

--- a/.github/workflows/candid.yaml
+++ b/.github/workflows/candid.yaml
@@ -10,9 +10,9 @@ jobs:
     name: validate candid syntax
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: install didc 0.3.2
-        uses: supplypike/setup-bin@v1
+        uses: supplypike/setup-bin@62a30439c59b5bd1431e7d812ba65e7ec4962d87 # v1
         with:
           uri: https://github.com/dfinity/candid/releases/download/2023-07-11/didc-linux64
           name: didc
@@ -25,12 +25,12 @@ jobs:
     name: validate candid matches rust
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/workflows/setup-rust
         with:
           cache: read
       - name: install didc 0.3.2
-        uses: supplypike/setup-bin@v1
+        uses: supplypike/setup-bin@62a30439c59b5bd1431e7d812ba65e7ec4962d87 # v1
         with:
           uri: https://github.com/dfinity/candid/releases/download/2023-07-11/didc-linux64
           name: didc

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -16,21 +16,21 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Restore dependencies from cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: ~/.npm
           key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: npm-
       - name: Restore Turborepo files from cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: frontend/.turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: "20.17.0"
       - name: Build frontend
@@ -43,13 +43,13 @@ jobs:
           OC_METERED_APIKEY: DUMMY_METERED_APIKEY
       - name: Save dependencies to cache
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: ~/.npm
           key: npm-${{ hashFiles('package-lock.json') }}
       - name: Save Turborepo files to cache
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: frontend/.turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -26,9 +26,9 @@ jobs:
       - name: Install Rustup
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/workflows/setup-rust
-      - uses: arduino/setup-protoc@v1
+      - uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build canister wasms

--- a/.github/workflows/pre_release_tests.yaml
+++ b/.github/workflows/pre_release_tests.yaml
@@ -18,12 +18,12 @@ jobs:
       - name: Install Rustup
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/workflows/setup-rust
         with:
           cache: read
       - name: Wait for wasms to be built
-        uses: lewagon/wait-on-check-action@v1.3.3
+        uses: lewagon/wait-on-check-action@595dabb3acf442d47e29c9ec9ba44db0c6bdd18f # v1.3.3
         with:
           ref: ${{ github.sha }}
           check-name: "Push canister wasms"

--- a/.github/workflows/push_canister_wasms.yaml
+++ b/.github/workflows/push_canister_wasms.yaml
@@ -15,11 +15,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Build canister wasms
         run: ./scripts/docker-build-all-wasms.sh
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:
           role-to-assume: arn:aws:iam::253040722768:role/GitHubActions-PushCanisterWasms
           aws-region: us-east-1


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `actions-rust-lang/rustfmt@v1` -> `actions-rust-lang/rustfmt@4066006ec54a31931b9b1fddfd38f2fdf2d27143 # v1.1.2`
  - Version: v1.1.2 | Latest: v1.1.2 | Release age: 116d
  - Commit: https://github.com/actions-rust-lang/rustfmt/commit/4066006ec54a31931b9b1fddfd38f2fdf2d27143

- `arduino/setup-protoc@v1` -> `arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1`
  - Version: v1 | Latest: v3.0.0 | Release age: 799d
  - Commit: https://github.com/arduino/setup-protoc/commit/149f6c87b92550901b26acd1632e11c3662e381f

- `actions-rs/cargo@v1` -> `actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3`
  - Version: v1.0.3 | Latest: v1.0.1 | Release age: 2398d
  - Commit: https://github.com/actions-rs/cargo/commit/844f36862e911db73fe0815f00a4a2602c279505

- `actions/upload-artifact@v4` -> `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2`
  - Version: v4.6.2 | Latest: v3.2.2 | Release age: 23d
  - Commit: https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02

- `dawidd6/action-download-artifact@v7` -> `dawidd6/action-download-artifact@80620a5d27ce0ae443b965134db88467fc607b43 # v7`
  - Version: v7 | Latest: v20 | Release age: 7d
  - Commit: https://github.com/dawidd6/action-download-artifact/commit/80620a5d27ce0ae443b965134db88467fc607b43
  - Warnings: 1 security advisory(ies) found, Action has 1 known advisory(ies)

- `thollander/actions-comment-pull-request@v3` -> `thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1`
  - Version: v3.0.1 | Latest: v3.0.1 | Release age: 524d
  - Commit: https://github.com/thollander/actions-comment-pull-request/commit/24bffb9b452ba05a4f3f77933840a6a841d1b32b

- `supplypike/setup-bin@v1` -> `supplypike/setup-bin@62a30439c59b5bd1431e7d812ba65e7ec4962d87 # v1`
  - Version: v1 | Latest: v5.0.0 | Release age: 231d
  - Commit: https://github.com/supplypike/setup-bin/commit/62a30439c59b5bd1431e7d812ba65e7ec4962d87

- `actions/cache/restore@v3` -> `actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0`
  - Version: v3.5.0 | Latest: v5.0.4 | Release age: 22d
  - Commit: https://github.com/actions/cache/commit/6f8efc29b200d32929f49075959781ed54ec270c

- `actions/setup-node@v3` -> `actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1`
  - Version: v3.9.1 | Latest: v6.3.0 | Release age: 37d
  - Commit: https://github.com/actions/setup-node/commit/3235b876344d2a9aa001b8d1453c930bba69e610

- `actions/cache/save@v3` -> `actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0`
  - Version: v3.5.0 | Latest: v5.0.4 | Release age: 22d
  - Commit: https://github.com/actions/cache/commit/6f8efc29b200d32929f49075959781ed54ec270c

- `lewagon/wait-on-check-action@v1.3.3` -> `lewagon/wait-on-check-action@595dabb3acf442d47e29c9ec9ba44db0c6bdd18f # v1.3.3`
  - Version: v1.3.3 | Latest: v1.6.1 | Release age: 11d
  - Commit: https://github.com/lewagon/wait-on-check-action/commit/595dabb3acf442d47e29c9ec9ba44db0c6bdd18f
  - Warnings: Latest release v1.6.1 is only 3 day(s) old (< 7 days). Using previous safe release.

- `aws-actions/configure-aws-credentials@v1` -> `aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0`
  - Version: v1.7.0 | Latest: v6.1.0 | Release age: 64d
  - Commit: https://github.com/aws-actions/configure-aws-credentials/commit/67fbcbb121271f7775d2e7715933280b06314838
  - Warnings: Latest release v6.1.0 is only 3 day(s) old (< 7 days). Using previous safe release.


### Files modified

- `.github/workflows/backend.yaml`
- `.github/workflows/benchmarks.yaml`
- `.github/workflows/build_caches.yaml`
- `.github/workflows/canbench-post-comment.yaml`
- `.github/workflows/candid.yaml`
- `.github/workflows/frontend.yaml`
- `.github/workflows/integration_tests.yaml`
- `.github/workflows/pre_release_tests.yaml`
- `.github/workflows/push_canister_wasms.yaml`

### Security warnings

- 1 security advisory(ies) found
- Action has 1 known advisory(ies)
- Latest release v1.6.1 is only 3 day(s) old (< 7 days). Using previous safe release.
- Latest release v6.1.0 is only 3 day(s) old (< 7 days). Using previous safe release.